### PR TITLE
fix(startup): crash on startup

### DIFF
--- a/Infrastracture/Settings.cs
+++ b/Infrastracture/Settings.cs
@@ -20,7 +20,6 @@ namespace Infrastracture
 
         public SettingsItem Load()
         {
-            CheckIfOptionsDirectoryExists();
             SettingsItem settingsItem = null;
             try
             {
@@ -39,7 +38,7 @@ namespace Infrastracture
             return settingsItem;
         }
 
-        private void CheckIfOptionsDirectoryExists()
+        public static void CheckIfOptionsDirectoryExists()
         {
             if(!Directory.Exists(Helper.AppConfigPath))
             {

--- a/NetShare/UI/Main.cs
+++ b/NetShare/UI/Main.cs
@@ -33,6 +33,7 @@ namespace NetShare
         }
         private void Form1_Load(object sender, EventArgs e)
         {
+            SettingFileHandler.CheckIfOptionsDirectoryExists();
             SetupKeyFile();
             InitializeBindingList();
             LoadApplicationOptions();


### PR DESCRIPTION
Application can crash and give an unhandle exception due to fact we missed to create a directory on first time. 
fix #35